### PR TITLE
Added first ADR of new architectural efforts

### DIFF
--- a/adr/0001-handling-build-warnings-as-errors.md
+++ b/adr/0001-handling-build-warnings-as-errors.md
@@ -1,0 +1,69 @@
+# Handling Build Warnings as Errors in .NET Projects
+
+* Status: accepted
+* Deciders: BCT Architecture Team
+* Date: 2025-03-07
+* Technical Story: [EPM-12597](https://terumobct.atlassian.net/browse/EPM-12597)
+
+## Context and Problem Statement
+
+The development team needs to establish a clear policy regarding the treatment of compiler warnings as errors in .NET projects across Terumo BCT. Initially, there was a goal to achieve builds with zero warnings to improve code quality and maintainability. However, practical implementation challenges have led to the need for a more flexible approach.
+
+## Decision Drivers
+
+* Code quality and maintainability requirements
+* Impact on development velocity and team productivity
+* Existing codebase with legacy warnings
+* Need for practical and sustainable implementation
+* Balance between strict quality standards and development efficiency
+
+## Considered Options
+
+* Option 1: Strict Enforcement (TreatWarningsAsErrors = true)
+* Option 2: Flexible Warning Management (Allow teams to manage warnings)
+
+## Decision Outcome
+
+Chosen option: "Flexible Warning Management", because it provides a balanced approach that maintains development velocity while encouraging good practices.
+
+Key points of the decision:
+* Projects are allowed to turn off the TreatWarningsAsErrors build option
+* Teams are advised to keep warnings to an absolute minimum
+* Warning management becomes a team responsibility rather than a strict enforcement
+
+### Positive Consequences
+
+* Maintains development velocity by preventing blocking builds due to warnings
+* Provides teams flexibility to handle legacy code and special cases
+* Allows for gradual improvement rather than enforcing immediate perfection
+* Reduces immediate impact on existing projects
+
+### Negative Consequences
+
+* Risk of warning accumulation over time if not properly managed
+* Potential inconsistency in warning handling across different projects
+* May require additional code review attention to prevent warning proliferation
+
+## Pros and Cons of the Options
+
+### Strict Enforcement
+
+* Good, because it enforces high code quality standards
+* Good, because it prevents warning accumulation
+* Good, because it ensures all code meets the same quality bar
+* Bad, because it can significantly impact development velocity
+* Bad, because it may require substantial effort to fix existing warnings
+* Bad, because it might lead to quick fixes rather than proper solutions
+
+### Flexible Warning Management
+
+* Good, because it maintains development velocity
+* Good, because it allows teams to manage their own quality trade-offs
+* Good, because it provides flexibility for legacy code
+* Bad, because it might lead to warning accumulation if not managed well
+* Bad, because it requires more discipline from development teams
+* Bad, because it could result in inconsistent practices across teams
+
+## Links
+
+* [EPM-12597](https://terumobct.atlassian.net/browse/EPM-12597) - Original EPIC discussing the treatment of warnings as errors

--- a/adr/ADR-template.md
+++ b/adr/ADR-template.md
@@ -1,0 +1,72 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION
# First ADR Publication and Migration to GitHub

## Changes Introduced
- Added first ADR (0001) documenting our decision regarding "Treat Warnings as Errors" policy for .NET development
- Establishes GitHub as the new home for Terumo BCT Applications Architecture ADRs

## Strategic Initiative
This PR represents the first step in migrating our Architectural Decision Records from SharePoint to GitHub. This migration aligns with industry best practices by:

1. Making ADRs more accessible to developers in their natural working environment
2. Enabling version control and change tracking of architectural decisions
3. Facilitating easier collaboration and discussion through PR reviews
4. Integrating architectural documentation directly with our development workflow

## Migration Plan
The Architecture Group will:
1. Review existing ADRs from SharePoint (currently at: https://terumobct.sharepoint.com/sites/rd/crossproductsoftware/Components/Forms/AllItems.aspx?id=%2Fsites%2Frd%2Fcrossproductsoftware%2FComponents%2FArchitectural%20Decision%20Records)
2. Gradually migrate and update them to this GitHub repository
3. Ensure all future ADRs are published directly to GitHub

## Reviewers Note
Please review:
- The content and format of the ADR
- The decision documentation clarity
- Any suggestions for improving our ADR process as we move forward with GitHub-based architectural documentation